### PR TITLE
Avif

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,9 @@ dependencies = [
  "anyhow",
  "clap",
  "image",
+ "nasm-rs 0.3.0",
+ "ravif",
+ "rgb",
  "webp",
 ]
 
@@ -562,6 +565,21 @@ dependencies = [
  "adler2",
  "simd-adler32",
 ]
+
+[[package]]
+name = "nasm-rs"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4d98d0065f4b1daf164b3eafb11974c94662e5e2396cf03f32d0bb5c17da51"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "nasm-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12fcfa1bd49e0342ec1d07ed2be83b59963e7acbeb9310e1bb2c07b69dadd959"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -769,6 +787,7 @@ dependencies = [
  "av1-grain",
  "bitstream-io",
  "built",
+ "cc",
  "cfg-if",
  "interpolate_name",
  "itertools",
@@ -776,6 +795,7 @@ dependencies = [
  "libfuzzer-sys",
  "log",
  "maybe-rayon",
+ "nasm-rs 0.2.5",
  "new_debug_unreachable",
  "noop_proc_macro",
  "num-derive",
@@ -832,6 +852,9 @@ name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "rustversion"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.95"
 clap = { version = "4.5.27", features = ["derive"] }
-image = "0.25.5"
+image = {version = "0.25.5", features = ["avif"]}
 nasm-rs = "0.3.0"
 ravif = "0.11.11"
 rgb = "0.8.50"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,7 @@ edition = "2021"
 anyhow = "1.0.95"
 clap = { version = "4.5.27", features = ["derive"] }
 image = "0.25.5"
+nasm-rs = "0.3.0"
+ravif = "0.11.11"
+rgb = "0.8.50"
 webp = "0.3.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,6 @@ impl Config {
     pub fn new() -> Config {
         let args = Args::parse();
 
-        println!("{args:?}");
         let format = match args
             .format
             .to_string()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::img_formats::ImageFormats;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
@@ -8,20 +9,39 @@ struct Args {
 
     #[arg(short, long)]
     dest: String,
+
+    #[arg(default_value_t=ImageFormats::WebP)]
+    format: ImageFormats,
 }
 
 pub struct Config {
     pub src: String,
     pub dest: String,
+    pub format: ImageFormats,
 }
 
 impl Config {
     pub fn new() -> Config {
         let args = Args::parse();
 
+        println!("{args:?}");
+        let format = match args
+            .format
+            .to_string()
+            .as_str()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "avif" => ImageFormats::Avif,
+            "webp" => ImageFormats::WebP,
+            _ => panic!("Unsupported format"),
+        };
+
         return Self {
             src: args.src,
             dest: args.dest,
+            format,
         };
     }
 }

--- a/src/convert_img.rs
+++ b/src/convert_img.rs
@@ -8,13 +8,15 @@ use std::{
 };
 
 use crate::{
-    convertor::to_webp,
+    convertor::{to_avif, to_webp},
+    img_formats::ImageFormats,
     utils::{read_file, write_file},
 };
 
 pub fn convert(
     src: &PathBuf,
     dest: &PathBuf,
+    format: &ImageFormats,
     converted: &mut usize,
     failed: &mut HashMap<OsString, Error>,
     skipped: &mut usize,
@@ -29,6 +31,7 @@ pub fn convert(
             convert(
                 &(entry.path()),
                 &dest.join(entry.file_name()),
+                format,
                 converted,
                 failed,
                 skipped,
@@ -36,7 +39,7 @@ pub fn convert(
             )?;
         } else {
             let path = entry.path();
-            let ext = path.extension().and_then(OsStr::to_str);
+            let ext: Option<&str> = path.extension().and_then(OsStr::to_str);
 
             let relative_path = path.strip_prefix(
                 path.parent()
@@ -45,11 +48,14 @@ pub fn convert(
 
             let output_path = dest.join(relative_path);
 
-            if ext.is_some_and(|ext| ext.eq("webp")) {
+            if ext.is_some_and(|ext| ext.eq(format.to_string().as_str())) {
                 *skipped += 1;
                 let file = read_file(path.as_path().as_ref())?;
                 write_file(&output_path, file.into_bytes())?;
-            } else if let Err(err) = convert_to_webp(&path, &output_path, 80) {
+            } else if let Err(err) = match format {
+                ImageFormats::WebP => convert_to_webp(src, dest, 80),
+                ImageFormats::Avif => convert_to_avif(src, dest, 80),
+            } {
                 failed.insert(entry.file_name(), err);
             } else {
                 *converted += 1;
@@ -78,5 +84,12 @@ fn convert_to_webp(src: &Path, dest: &Path, quality: u8) -> Result<()> {
     let img = read_file(src)?;
     let webp_data = to_webp(img, quality)?;
     write_file(&dest.with_extension("webp"), webp_data.as_ref())?;
+    Ok(())
+}
+
+fn convert_to_avif(src: &Path, dest: &Path, quality: u8) -> Result<()> {
+    let img = read_file(src)?;
+    let avif_data = to_avif(img, quality)?;
+    write_file(&dest.with_extension("webp"), avif_data.avif_file)?;
     Ok(())
 }

--- a/src/convert_img.rs
+++ b/src/convert_img.rs
@@ -47,18 +47,26 @@ pub fn convert(
             )?;
 
             let output_path = dest.join(relative_path);
+            // println!("{path:?}");
 
-            if ext.is_some_and(|ext| ext.eq(format.to_string().as_str())) {
+            if ext.is_some_and(|ext| ext.eq(format.to_string().as_str()) && ext != "avif".to_string())  {
+
                 *skipped += 1;
+                // println!("Skipping 1");
                 let file = read_file(path.as_path().as_ref())?;
                 write_file(&output_path, file.into_bytes())?;
+
             } else if let Err(err) = match format {
-                ImageFormats::WebP => convert_to_webp(src, dest, 80),
-                ImageFormats::Avif => convert_to_avif(src, dest, 80),
+
+                ImageFormats::WebP => convert_to_webp(path.as_path(), &output_path, 80),
+                ImageFormats::Avif => convert_to_avif(path.as_path(), &output_path, 80),
+
             } {
                 failed.insert(entry.file_name(), err);
             } else {
+
                 *converted += 1;
+            
             };
 
             let total_processed = *converted + *skipped + failed.len();
@@ -88,8 +96,9 @@ fn convert_to_webp(src: &Path, dest: &Path, quality: u8) -> Result<()> {
 }
 
 fn convert_to_avif(src: &Path, dest: &Path, quality: u8) -> Result<()> {
+    // println!("{src:?}");
     let img = read_file(src)?;
     let avif_data = to_avif(img, quality)?;
-    write_file(&dest.with_extension("webp"), avif_data.avif_file)?;
+    write_file(&dest.with_extension("avif"), avif_data.avif_file)?;
     Ok(())
 }

--- a/src/convertor.rs
+++ b/src/convertor.rs
@@ -14,11 +14,14 @@ pub fn to_webp(img: DynamicImage, quality: u8) -> Result<WebPMemory> {
 }
 
 pub fn to_avif(img: DynamicImage, quality: u8) -> Result<EncodedImage, ravif::Error> {
+    
     let (width, height) = img.dimensions();
     let encoder = AvifEncoder::new()
         .with_quality(quality as f32)
-        .with_speed(1);
-    let data = img.as_bytes().as_rgba();
+        .with_speed(10);
+    let raw_image = img.to_rgba8().into_raw();
+    let rgba_img = raw_image.as_slice().as_rgba();
+    let data = Img::new(rgba_img, width as usize, height as usize);
 
-    return encoder.encode_rgba(Img::new(data, width as usize, height as usize));
+    return encoder.encode_rgba(data);
 }

--- a/src/convertor.rs
+++ b/src/convertor.rs
@@ -1,12 +1,24 @@
 use anyhow::Result;
 use image::{DynamicImage, GenericImageView};
-use webp::{Encoder, WebPMemory};
+use ravif::{EncodedImage, Encoder as AvifEncoder, Img};
+use rgb::FromSlice;
+use webp::{Encoder as WebpEncoder, WebPMemory};
 
 pub fn to_webp(img: DynamicImage, quality: u8) -> Result<WebPMemory> {
     let (width, height) = img.dimensions();
     let binding = img.to_rgba8();
-    let encoder = Encoder::from_rgba(binding.as_raw(), width, height);
+    let encoder = WebpEncoder::from_rgba(binding.as_raw(), width, height);
     let webp_data = encoder.encode(quality as f32);
 
     return Ok(webp_data);
+}
+
+pub fn to_avif(img: DynamicImage, quality: u8) -> Result<EncodedImage, ravif::Error> {
+    let (width, height) = img.dimensions();
+    let encoder = AvifEncoder::new()
+        .with_quality(quality as f32)
+        .with_speed(1);
+    let data = img.as_bytes().as_rgba();
+
+    return encoder.encode_rgba(Img::new(data, width as usize, height as usize));
 }

--- a/src/img_formats.rs
+++ b/src/img_formats.rs
@@ -1,0 +1,29 @@
+use anyhow::anyhow;
+use std::str::FromStr;
+
+#[derive(Clone, Debug)]
+pub enum ImageFormats {
+    WebP,
+    Avif,
+}
+
+impl FromStr for ImageFormats {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "webp" => Ok(ImageFormats::WebP),
+            "avif" => Ok(ImageFormats::Avif),
+            _ => Err(anyhow!("Invalid Format")),
+        }
+    }
+}
+
+impl ToString for ImageFormats {
+    fn to_string(&self) -> String {
+        return match self {
+            ImageFormats::WebP => String::from("webp"),
+            ImageFormats::Avif => String::from("avif"),
+        };
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod convert_img;
 mod convertor;
+mod img_formats;
 mod utils;
 
 use anyhow::Error;
@@ -30,6 +31,7 @@ fn main() {
         convert_img::convert(
             &src,
             &dest,
+            &config.format,
             &mut converted,
             &mut failed,
             &mut skipped,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,10 +7,12 @@ use anyhow::{Context, Result};
 use image::{DynamicImage, ImageReader};
 
 pub fn read_file(src: &Path) -> Result<DynamicImage> {
+    
     let img = ImageReader::open(src)
-        .with_context(|| format!("Failed to open image: {:?}", src))?
-        .decode()
-        .with_context(|| format!("Failed to decode image: {:?}", src))?;
+    .with_context(|| format!("Failed to open image: {:?}", src))?
+    .decode()
+    // .map_err(|e| {eprintln!("{e}:?"); e})
+    .with_context(|| format!("Failed to decode image: {:?}", src))?;
 
     return Ok(img);
 }


### PR DESCRIPTION
# Adds the ability to convert the image to avif format

## Usage
The program now accepts a new argument (use -h for detailed info)
```bash
iimg-convert.exe --src <SRC> --dest <DEST> [FORMAT]
```

## Issues
The program still has the issue where it's unable to read `.avif` files. Refer to #7 for more details and current status of the issue.

## Resolves
This pull request resolves #6 